### PR TITLE
Add rails makimodoshi with schema.rb diff detection

### DIFF
--- a/lib/makimodoshi/schema_diff_detector.rb
+++ b/lib/makimodoshi/schema_diff_detector.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Makimodoshi
+  class SchemaDiffDetector
+    class << self
+      def schema_matches?
+        on_disk = read_schema_file
+        return true unless on_disk
+
+        from_db = dump_current_schema
+        normalize(on_disk) == normalize(from_db)
+      end
+
+      def dump_current_schema
+        # Railtie が設定済みのはずだが、rake タスク単独実行時にも
+        # 隠しテーブルを除外するための防御的チェック
+        unless ActiveRecord::SchemaDumper.ignore_tables.include?(HIDDEN_TABLE_NAME)
+          ActiveRecord::SchemaDumper.ignore_tables << HIDDEN_TABLE_NAME
+        end
+
+        stream = StringIO.new
+        # Rails 7.2+ では SchemaDumper.dump の第一引数が connection から
+        # connection_pool に変更された
+        if pool_based_schema_dumper?
+          ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+        else
+          ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+        end
+        stream.string
+      end
+
+      def read_schema_file
+        schema_file = Rails.root.join("db", "schema.rb")
+        return nil unless File.exist?(schema_file)
+
+        File.read(schema_file)
+      end
+
+      private
+
+      def pool_based_schema_dumper?
+        ActiveRecord::VERSION::MAJOR >= 8 ||
+          (ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR >= 2)
+      end
+
+      def normalize(schema)
+        schema
+          .lines
+          .reject { |line| line.strip.start_with?("#") || line.strip.empty? }
+          .map(&:rstrip)
+          .join("\n")
+      end
+    end
+  end
+end

--- a/lib/tasks/makimodoshi.rake
+++ b/lib/tasks/makimodoshi.rake
@@ -1,5 +1,50 @@
 # frozen_string_literal: true
 
+desc "Rollback excess migrations until DB schema matches schema.rb"
+task makimodoshi: :environment do
+  require "makimodoshi/schema_checker"
+  require "makimodoshi/schema_diff_detector"
+  require "makimodoshi/migration_store"
+  require "makimodoshi/rollbacker"
+
+  unless Makimodoshi.development?
+    $stderr.puts "[makimodoshi] This command is only available in development environment."
+    exit 1
+  end
+
+  if Makimodoshi::SchemaDiffDetector.schema_matches?
+    $stdout.puts "[makimodoshi] DB schema matches schema.rb. Nothing to do."
+    next
+  end
+
+  $stdout.puts "[makimodoshi] DB schema differs from schema.rb. Rolling back..."
+
+  loop do
+    excess = Makimodoshi::SchemaChecker.excess_versions
+    if excess.empty?
+      if Makimodoshi::SchemaDiffDetector.schema_matches?
+        $stdout.puts "[makimodoshi] Schema now matches. Rollback complete."
+      else
+        $stderr.puts "[makimodoshi] No more excess migrations but schema still differs from schema.rb."
+        $stderr.puts "[makimodoshi] You may need to run 'rails db:migrate' to apply pending migrations."
+        exit 1
+      end
+      break
+    end
+
+    success = Makimodoshi::Rollbacker.rollback_one(excess.first)
+    unless success
+      $stderr.puts "[makimodoshi] Failed to rollback migration #{excess.first}. Check logs for details."
+      exit 1
+    end
+
+    if Makimodoshi::SchemaDiffDetector.schema_matches?
+      $stdout.puts "[makimodoshi] Schema now matches. Rollback complete."
+      break
+    end
+  end
+end
+
 namespace :makimodoshi do
   desc "Show stored migrations available for rollback"
   task status: :environment do

--- a/spec/makimodoshi/schema_diff_detector_spec.rb
+++ b/spec/makimodoshi/schema_diff_detector_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+
+RSpec.describe Makimodoshi::SchemaDiffDetector do
+  let(:schema_dir) { Rails.root.join("db") }
+  let(:schema_file) { schema_dir.join("schema.rb") }
+
+  before do
+    FileUtils.mkdir_p(schema_dir)
+    ActiveRecord::SchemaDumper.ignore_tables << Makimodoshi::HIDDEN_TABLE_NAME unless
+      ActiveRecord::SchemaDumper.ignore_tables.include?(Makimodoshi::HIDDEN_TABLE_NAME)
+  end
+
+  after do
+    FileUtils.rm_f(schema_file)
+    conn = ActiveRecord::Base.connection
+    conn.drop_table(:diff_test_posts) if conn.table_exists?(:diff_test_posts)
+  end
+
+  describe ".schema_matches?" do
+    it "returns true when schema.rb does not exist" do
+      FileUtils.rm_f(schema_file)
+      expect(described_class.schema_matches?).to be true
+    end
+
+    it "returns true when DB schema matches schema.rb" do
+      # DB の現在の状態をダンプして schema.rb に書き込む
+      current_schema = described_class.dump_current_schema
+      File.write(schema_file, current_schema)
+
+      expect(described_class.schema_matches?).to be true
+    end
+
+    it "returns false when DB has extra tables not in schema.rb" do
+      # まず現在の状態で schema.rb を生成
+      current_schema = described_class.dump_current_schema
+      File.write(schema_file, current_schema)
+
+      # テーブルを追加して DB を変更
+      ActiveRecord::Base.connection.create_table(:diff_test_posts) do |t|
+        t.string :title
+      end
+
+      expect(described_class.schema_matches?).to be false
+    end
+
+    it "returns false when DB is missing tables present in schema.rb" do
+      # テーブルがある状態でスキーマを書き出す
+      ActiveRecord::Base.connection.create_table(:diff_test_posts) do |t|
+        t.string :title
+      end
+      current_schema = described_class.dump_current_schema
+      File.write(schema_file, current_schema)
+
+      # テーブルを削除して DB を変更
+      ActiveRecord::Base.connection.drop_table(:diff_test_posts)
+
+      expect(described_class.schema_matches?).to be false
+    end
+
+    it "ignores comment-only differences" do
+      current_schema = described_class.dump_current_schema
+      # コメントを追加しても差分なしと判定
+      schema_with_extra_comments = "# Extra comment\n" + current_schema
+      File.write(schema_file, schema_with_extra_comments)
+
+      expect(described_class.schema_matches?).to be true
+    end
+  end
+
+  describe ".dump_current_schema" do
+    it "returns a string containing ActiveRecord::Schema" do
+      schema = described_class.dump_current_schema
+      expect(schema).to include("ActiveRecord::Schema")
+    end
+
+    it "excludes the hidden makimodoshi table" do
+      Makimodoshi::MigrationStore.ensure_table!
+      schema = described_class.dump_current_schema
+      expect(schema).not_to include(Makimodoshi::HIDDEN_TABLE_NAME)
+    end
+  end
+
+  describe ".read_schema_file" do
+    it "returns file contents when schema.rb exists" do
+      File.write(schema_file, "test content")
+      expect(described_class.read_schema_file).to eq("test content")
+    end
+
+    it "returns nil when schema.rb does not exist" do
+      FileUtils.rm_f(schema_file)
+      expect(described_class.read_schema_file).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "makimodoshi/migration_store"
 require "makimodoshi/schema_checker"
 require "makimodoshi/rollbacker"
 require "makimodoshi/migration_interceptor"
+require "makimodoshi/schema_diff_detector"
 
 # Setup in-memory SQLite database for testing
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")


### PR DESCRIPTION
## Summary
- `rails makimodoshi` コマンドを新規追加。schema.rbとDBの内容差分を検知し、差分がなくなるまでマイグレーションをロールバックする
- `SchemaDiffDetector` クラスで `ActiveRecord::SchemaDumper` を使いDBスキーマをダンプし、disk上の `schema.rb` と内容比較
- Rails 6.1〜8.1+ の `SchemaDumper.dump` API変更（connection → connection_pool）に互換対応

## 動作フロー
1. `SchemaDiffDetector.schema_matches?` でDBダンプとschema.rbを比較
2. 差分があれば `SchemaChecker.excess_versions` で超過バージョンを特定
3. 最新の超過バージョンを1つロールバック
4. 再度スキーマ比較し、一致するまでループ
5. 超過バージョンがなくなっても差分が残る場合はエラー通知

## Test plan
- [x] `SchemaDiffDetector` の単体テスト（9ケース）
- [x] 既存テスト全36件がパスすることを確認
- [ ] 実際のRailsアプリでブランチ切り替え後に `rails makimodoshi` を実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)