### PR TITLE
Fix RuntimeError being silently swallowed in rollback_one

### DIFF
--- a/lib/makimodoshi.rb
+++ b/lib/makimodoshi.rb
@@ -8,6 +8,7 @@ module Makimodoshi
   HIDDEN_TABLE_NAME = "_makimodoshi_migrations"
 
   class InvalidMigrationSourceError < StandardError; end
+  class MigrationClassLoadError < StandardError; end
 
   LOGGER_MUTEX = Mutex.new
 

--- a/lib/makimodoshi/rollbacker.rb
+++ b/lib/makimodoshi/rollbacker.rb
@@ -34,7 +34,7 @@ module Makimodoshi
 
         logger.info("[makimodoshi] Rolled back #{version}.")
         true
-      rescue InvalidMigrationSourceError
+      rescue InvalidMigrationSourceError, MigrationClassLoadError
         raise
       rescue => e
         logger.error("[makimodoshi] Failed to rollback migration #{version}: #{e.message}")
@@ -50,7 +50,7 @@ module Makimodoshi
         # Extract class name from source code
         class_name = source.match(/class\s+(\w+)\s*</)&.captures&.first
 
-        raise "Could not determine migration class name from source for #{version}" unless class_name
+        raise MigrationClassLoadError, "Could not determine migration class name from source for #{version}" unless class_name
 
         unless Object.const_defined?(class_name, false)
           # Tempfile + load は class_eval より安全:

--- a/spec/makimodoshi/rollbacker_spec.rb
+++ b/spec/makimodoshi/rollbacker_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe Makimodoshi::Rollbacker do
       expect { described_class.rollback_one(version) }.to raise_error(Makimodoshi::InvalidMigrationSourceError, /dangerous method calls/)
     end
 
+    it "raises MigrationClassLoadError when class name cannot be determined" do
+      # Create a mutable source string to allow stubbing
+      mutable_source = +source.dup
+      allow(Makimodoshi::MigrationStore).to receive(:fetch).with(version).and_return(
+        "migration_source" => mutable_source,
+        "filename" => filename
+      )
+      # Stub match so validation passes (via match?) but class_name extraction returns nil
+      allow(mutable_source).to receive(:match).with(/class\s+(\w+)\s*</).and_return(nil)
+
+      expect { described_class.rollback_one(version) }.to raise_error(Makimodoshi::MigrationClassLoadError)
+    end
+
     it "raises InvalidMigrationSourceError for code after class definition" do
       malicious_source = <<~RUBY
         class TrojanMigration < ActiveRecord::Migration[#{migration_version}]


### PR DESCRIPTION
## Summary
- Add `MigrationClassLoadError < StandardError` error class to `Makimodoshi` module
- Replace generic `RuntimeError` with `MigrationClassLoadError` when class name extraction fails in `load_migration_class`
- Add `MigrationClassLoadError` to the re-raise rescue chain so it propagates instead of being caught by `rescue => e`
- Add test verifying the error is raised and not silently swallowed

## Test plan
- [x] `bundle exec rspec` passes (37 examples, 0 failures)
- [x] New test verifies `MigrationClassLoadError` is raised when class name cannot be determined
- [x] Existing tests for `InvalidMigrationSourceError`, happy path rollback, and error logging all continue to pass

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)