### PR TITLE
Fix class name collision in load_migration_class

### DIFF
--- a/lib/makimodoshi/rollbacker.rb
+++ b/lib/makimodoshi/rollbacker.rb
@@ -52,15 +52,21 @@ module Makimodoshi
 
         raise "Could not determine migration class name from source for #{version}" unless class_name
 
-        unless Object.const_defined?(class_name, false)
-          # Tempfile + load は class_eval より安全:
-          # - ファイルパスがスタックトレースに表示される
-          # - Ruby パーサを経由するため、eval 特有の攻撃ベクタを回避
-          Tempfile.create(["migration_#{version}_", ".rb"]) do |f|
-            f.write(source)
-            f.flush
-            load f.path
-          end
+        # 同名クラスが既に定義されている場合は削除して、
+        # 正しいバージョンのソースコードからクラスを再定義する。
+        # これにより、異なるバージョンで同じクラス名（例: AddColumnToUsers）を
+        # 使っている場合の名前衝突を防ぐ。
+        if Object.const_defined?(class_name, false)
+          Object.send(:remove_const, class_name)
+        end
+
+        # Tempfile + load は class_eval より安全:
+        # - ファイルパスがスタックトレースに表示される
+        # - Ruby パーサを経由するため、eval 特有の攻撃ベクタを回避
+        Tempfile.create(["migration_#{version}_", ".rb"]) do |f|
+          f.write(source)
+          f.flush
+          load f.path
         end
 
         Object.const_get(class_name)

--- a/spec/makimodoshi/rollbacker_spec.rb
+++ b/spec/makimodoshi/rollbacker_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Makimodoshi::Rollbacker do
   after do
     conn = ActiveRecord::Base.connection
     conn.drop_table(:posts_for_test) if conn.table_exists?(:posts_for_test)
+    conn.drop_table(:posts_for_test_v2) if conn.table_exists?(:posts_for_test_v2)
   end
 
   describe ".rollback_one" do
@@ -97,6 +98,45 @@ RSpec.describe Makimodoshi::Rollbacker do
       Makimodoshi::MigrationStore.store(version: version, filename: filename, source: dangerous_source)
 
       expect { described_class.rollback_one(version) }.to raise_error(Makimodoshi::InvalidMigrationSourceError, /dangerous method calls/)
+    end
+
+    it "handles class name collision by reloading from correct source" do
+      # Create a second migration with the same class name but different behavior
+      version2 = "20240301000000"
+      filename2 = "20240301000000_create_posts_for_test.rb"
+      source2 = <<~RUBY
+        class CreatePostsForTest < ActiveRecord::Migration[#{migration_version}]
+          def up
+            create_table :posts_for_test_v2 do |t|
+              t.string :title
+              t.timestamps
+            end
+          end
+
+          def down
+            drop_table :posts_for_test_v2
+          end
+        end
+      RUBY
+
+      conn = ActiveRecord::Base.connection
+      conn.execute(ActiveRecord::Base.sanitize_sql_array(
+        ["INSERT INTO schema_migrations (version) VALUES (?)", version2]
+      ))
+      Makimodoshi::MigrationStore.store(version: version2, filename: filename2, source: source2)
+      conn.create_table(:posts_for_test_v2) do |t|
+        t.string :title
+        t.timestamps
+      end
+
+      # Rollback the first version (which defines CreatePostsForTest)
+      described_class.rollback_one(version)
+      expect(conn.table_exists?(:posts_for_test)).to be false
+
+      # Now rollback the second version (same class name, different behavior)
+      # This should reload the class with the new source, not use the old definition
+      described_class.rollback_one(version2)
+      expect(conn.table_exists?(:posts_for_test_v2)).to be false
     end
 
     it "raises InvalidMigrationSourceError for code after class definition" do


### PR DESCRIPTION
## Summary
- Fix `Rollbacker#load_migration_class` to always remove existing constant before loading new migration source, preventing class name collisions when different migration versions share the same class name (e.g., `AddColumnToUsers`)
- Add test verifying two migrations with the same class name (`CreatePostsForTest`) but different `down` methods are each rolled back correctly

## Test plan
- [x] `bundle exec rspec` passes (37 examples, 0 failures)
- [x] New test `"handles class name collision by reloading from correct source"` confirms the fix

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)