### PR TITLE
zizmor CIを追加しREADMEの説明を現行仕様に合わせる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -34,10 +38,12 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ When `rails s` starts, makimodoshi compares the `schema.rb` version with the dat
 
 ```
 $ rails s
-[makimodoshi] DB is ahead of schema.rb by 2 migration(s): 20240301000000, 20240201000000
-[makimodoshi] Auto-rolling back...
+[makimodoshi] schema.rb has git diff and 2 orphan migration(s) without files: 20240301000000, 20240201000000
+[makimodoshi] Auto-rolling back to align with git schema...
 [makimodoshi] Rolling back 20240301000000 (20240301000000_add_tags_to_posts.rb)...
 [makimodoshi] Rolled back 20240301000000.
 [makimodoshi] Rolling back 20240201000000 (20240201000000_create_comments.rb)...
@@ -99,7 +99,7 @@ Roll back a specific version:
 $ rails makimodoshi:rollback VERSION=20240201000000
 ```
 
-### Rollback all excess migrations
+### Rollback all orphan migrations
 
 ```
 $ rails makimodoshi:rollback_all
@@ -117,6 +117,7 @@ $ git checkout main       # Migration files disappear, DB still has the changes
 
 $ rails makimodoshi:rollback
                           # Explicitly roll back the most recent orphan migration when schema.rb has no git diff
+# Repeat as needed when multiple orphan migrations remain
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ $ rails makimodoshi:rollback VERSION=20240201000000
 $ rails makimodoshi:rollback_all
 ```
 
+This task uses the same `db/schema.rb` git-diff guard as automatic rollback. If orphan migrations exist but `db/schema.rb` has no git diff, use `rails makimodoshi:rollback` to roll them back intentionally, one migration at a time.
+
 ## Typical Workflow
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/s4na/makimodoshi/actions/workflows/ci.yml/badge.svg)](https://github.com/s4na/makimodoshi/actions/workflows/ci.yml)
 
-**makimodoshi** is a Rails gem that automatically rolls back excess database migrations when starting `rails s`. It solves the common pain point of branch switching leaving behind applied migrations that no longer exist in the current branch.
+**makimodoshi** is a Rails gem that helps roll back orphaned database migrations that no longer exist in the current branch. It solves the common pain point of branch switching leaving behind applied migrations after their files disappear.
 
 ## The Problem
 
@@ -17,7 +17,7 @@ The usual fix is `db:rollback` (hoping the files still exist) or `db:reset` (los
 
 ## The Solution
 
-makimodoshi hooks into `rails s` startup and automatically detects when the database is ahead of `schema.rb`. When it finds excess migrations, it rolls them back using stored migration source code — even if the original migration files have been deleted by a branch switch.
+makimodoshi stores migration source code when migrations are applied, then uses that stored source to roll back orphan migrations when needed — even if the original migration files have been deleted by a branch switch.
 
 ## Installation
 
@@ -50,7 +50,7 @@ Every time you run `db:migrate`, makimodoshi saves a copy of each migration's so
 
 ### 2. Automatic Rollback (`rails s`)
 
-When `rails s` starts, makimodoshi compares the `schema.rb` version with the database's `schema_migrations` table. If the DB is ahead, it automatically rolls back the excess migrations using the stored source code.
+When `rails s` starts, makimodoshi compares the `schema.rb` version with the database's `schema_migrations` table. If the DB is ahead, the excess migration files are missing, and `db/schema.rb` has a git diff, it automatically rolls back the orphan migrations using the stored source code.
 
 ```
 $ rails s
@@ -65,11 +65,14 @@ $ rails s
 ...
 ```
 
+If orphan migrations exist but `db/schema.rb` has no git diff, makimodoshi skips automatic rollback. In that case, run `rails makimodoshi:rollback` or `rails makimodoshi:rollback_all` when you intentionally want to roll them back.
+
 ### 3. Safety
 
 - **Development only**: All DB operations are restricted to `Rails.env.development?`. In any other environment, the gem does nothing and prints a warning.
 - **No schema pollution**: The hidden table is excluded from `schema.rb` via `SchemaDumper.ignore_tables`.
 - **No-op when in sync**: If the DB matches `schema.rb`, startup cost is minimal (one file read + one DB query).
+- **Git diff guard**: Automatic rollback only runs when `db/schema.rb` has a git diff, avoiding surprise rollback immediately after a branch checkout.
 
 ## Rake Tasks
 
@@ -110,12 +113,13 @@ $ rails db:migrate        # Migrations are applied and stored by makimodoshi
 
 $ git checkout main       # Migration files disappear, DB still has the changes
 
-$ rails s                 # makimodoshi detects the mismatch and auto-rolls back
+$ rails makimodoshi:rollback_all
+                          # Explicitly roll back orphan migrations when schema.rb has no git diff
 ```
 
 ## Requirements
 
-- Ruby >= 2.7
+- Ruby >= 3.0
 - Rails >= 6.1
 - `schema.rb` based projects (`structure.sql` is not supported)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ rails s
 ...
 ```
 
-If orphan migrations exist but `db/schema.rb` has no git diff, makimodoshi skips automatic rollback. In that case, run `rails makimodoshi:rollback` or `rails makimodoshi:rollback_all` when you intentionally want to roll them back.
+If orphan migrations exist but `db/schema.rb` has no git diff, makimodoshi skips automatic rollback. In that case, run `rails makimodoshi:rollback` when you intentionally want to roll back the most recent orphan migration.
 
 ### 3. Safety
 
@@ -113,8 +113,8 @@ $ rails db:migrate        # Migrations are applied and stored by makimodoshi
 
 $ git checkout main       # Migration files disappear, DB still has the changes
 
-$ rails makimodoshi:rollback_all
-                          # Explicitly roll back orphan migrations when schema.rb has no git diff
+$ rails makimodoshi:rollback
+                          # Explicitly roll back the most recent orphan migration when schema.rb has no git diff
 ```
 
 ## Requirements

--- a/makimodoshi.gemspec
+++ b/makimodoshi.gemspec
@@ -6,10 +6,9 @@ Gem::Specification.new do |spec|
   spec.name = "makimodoshi"
   spec.version = Makimodoshi::VERSION
   spec.authors = ["s4na"]
-  spec.summary = "Auto-rollback migrations when DB is ahead of schema.rb"
-  spec.description = "A Rails gem that automatically rolls back migrations on server startup " \
-                     "when the database state is ahead of schema.rb. Useful for branch switching " \
-                     "during development."
+  spec.summary = "Rollback orphaned Rails migrations after branch switches"
+  spec.description = "A Rails gem that stores migration source code and helps roll back " \
+                     "orphaned migrations after branch switches during development."
   spec.homepage = "https://github.com/s4na/makimodoshi"
   spec.license = "MIT"
 


### PR DESCRIPTION
## 概要

GitHub Actions の `zizmor` 監査CIを追加し、既存CIも `zizmor` が通るように最小限 hardening しました。あわせて README と gemspec のロールバック説明を、現在の orphan migration 対象の挙動に合わせています。

## 変更内容

- `.github/workflows/zizmor.yml` を追加し、PR / main push で `zizmor` を実行
- 既存CIに `permissions` を明示し、`actions/checkout` の `persist-credentials: false` を設定
- `actions/checkout`、`ruby/setup-ruby`、`zizmorcore/zizmor-action` を commit SHA で pinning
- 自動ロールバックの条件を「orphan migration かつ `db/schema.rb` に git diff がある場合」として README に明記
- `makimodoshi:rollback` と `makimodoshi:rollback_all` の git-diff guard の違いを明確化
- README / gemspec の Ruby 要件と説明を現行実装に合わせて更新

## 背景

README と gemspec には、以前の「DB が schema.rb より進んでいれば自動ロールバックする」説明や Ruby 2.7 サポート表記が残っていました。また、`zizmor` CIを追加するにあたり、既存 workflow の未pinned action、広いデフォルト権限、checkout credential persistence が `zizmor` の finding になるため、同じPR内で修正しています。

## 確認

- `actionlint`
- `zizmor .`（No findings）
- `bundle exec rspec`（57 examples, 0 failures）
- `git diff --check`
- 非投稿レビューを複数回実施し、指摘を反映済み

## 補足

README / gemspec / workflow の変更で、非自明なコード実装箇所はないため `annotate-pr-intent` のインライン意図コメントは投稿していません。
